### PR TITLE
Better progress bar for notebooks

### DIFF
--- a/rudalle/pipelines.py
+++ b/rudalle/pipelines.py
@@ -5,7 +5,7 @@ import transformers
 import more_itertools
 import numpy as np
 import matplotlib.pyplot as plt
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from . import utils
 


### PR DESCRIPTION
This PR renders a nicer HTML progress bar for Jupyter, Colab, and IPython notebooks if they support it (similar to the one already used for downloading DALLE). If it's run in normal python, it will default to the usual progress bar.